### PR TITLE
Fix for similar animation names

### DIFF
--- a/lib/scopeify.js
+++ b/lib/scopeify.js
@@ -50,11 +50,11 @@ function replaceAnimations(result) {
 
   if (unscoped.length) {
     var regexStr = '((?:animation|animation-name)\\s*:[^};]*)('
-      + unscoped.join('|') + ')' + ignoreComments;
+      + unscoped.join('|') + ')([;\\s])' + ignoreComments;
     var regex = new RegExp(regexStr, 'g');
 
-    var replaced = result.css.replace(regex, function(match, preamble, name) {
-      return preamble + animations[name];
+    var replaced = result.css.replace(regex, function(match, preamble, name, ending) {
+      return preamble + animations[name] + ending;
     });
 
     return {

--- a/test/keyframes-usage.expected.css
+++ b/test/keyframes-usage.expected.css
@@ -1,6 +1,10 @@
 
 
- .woo_2a0vea {
-    animation: yolo_2OKdOh 5s infinite;
+ .woo_2MFmAf {
+    animation: yolo_4lrRRM 5s infinite;
   }
+
+  .boo_2MFmAf {
+     animation-name: yoloYolo_4lrRRM;
+   }
 

--- a/test/keyframes-usage.expected.json
+++ b/test/keyframes-usage.expected.json
@@ -1,3 +1,4 @@
 {
-  "woo": "woo_2a0vea"
+  "boo": "boo_2MFmAf",
+  "woo": "woo_2MFmAf"
 }

--- a/test/keyframes-usage.source.js
+++ b/test/keyframes-usage.source.js
@@ -8,4 +8,8 @@ module.exports = csjs`
     animation: ${keyframes.yolo} 5s infinite;
   }
 
+  .boo {
+     animation-name: ${keyframes.yoloYolo};
+   }
+
 `;

--- a/test/keyframes.expected.css
+++ b/test/keyframes.expected.css
@@ -1,11 +1,20 @@
 
 
-  @keyframes yolo_2OKdOh {
+  @keyframes yolo_4lrRRM {
     0%   { opacity: 0; }
     100% { opacity: 1; }
   }
 
-  .foo_2OKdOh {
-    animation: yolo_2OKdOh 5s infinite;
+  .foo_4lrRRM {
+    animation: yolo_4lrRRM 5s infinite;
+  }
+
+  @keyframes yoloYolo_4lrRRM {
+    0%   { opacity: 0; }
+    100% { opacity: 1; }
+  }
+
+  .bar_4lrRRM {
+    animation: yoloYolo_4lrRRM 5s infinite;
   }
 

--- a/test/keyframes.expected.json
+++ b/test/keyframes.expected.json
@@ -1,4 +1,6 @@
 {
-  "yolo": "yolo_2OKdOh",
-  "foo": "foo_2OKdOh"
+  "yolo": "yolo_4lrRRM",
+  "yoloYolo": "yoloYolo_4lrRRM",
+  "foo": "foo_4lrRRM",
+  "bar": "bar_4lrRRM"
 }

--- a/test/keyframes.source.js
+++ b/test/keyframes.source.js
@@ -11,4 +11,13 @@ module.exports = csjs`
     animation: yolo 5s infinite;
   }
 
+  @keyframes yoloYolo {
+    0%   { opacity: 0; }
+    100% { opacity: 1; }
+  }
+
+  .bar {
+    animation: yoloYolo 5s infinite;
+  }
+
 `;


### PR DESCRIPTION
When creating [this library](https://github.com/shama/animate-styles) I noticed that some of the similar animation names were incorrect.

For instance, if we had animations named `bounce`, `bounceIn`, `bounceInDown` it would result in:
```css
animation-name: bounceIn_3YDk0BDown;
```
instead of:
```css
animation-name: bounceInDown_3YDk0B;
```

This PR makes it check more explicitly for the animation name. Thanks!