### PR TITLE
Improve performance of extractExtends()

### DIFF
--- a/lib/css-extract-extends.js
+++ b/lib/css-extract-extends.js
@@ -5,6 +5,14 @@ var makeComposition = require('./composition').makeComposition;
 var regex = /\.([^\s]+)(\s+)(extends\s+)(\.[^{]+)/g;
 
 module.exports = function extractExtends(css, hashed) {
+  var extracted = {
+    css: css,
+    compositions: {}
+  };
+
+  // skip all the work if no extends are present in the css string
+  if (!/\sextends\s/.test(css)) return extracted;
+
   var found, matches = [];
   while (found = regex.exec(css)) {
     matches.unshift(found);
@@ -34,10 +42,7 @@ module.exports = function extractExtends(css, hashed) {
     return acc;
   }
 
-  return matches.reduce(extractCompositions, {
-    css: css,
-    compositions: {}
-  });
+  return matches.reduce(extractCompositions, extracted);
 
 };
 


### PR DESCRIPTION
We can skip all the work that `extractExtends()` performs with a trivial check for `\sextends\s` in the passed CSS string.  I don't have numbers, but I believe this will increase performance non-insignificantly 😉 
#39
