### PR TITLE
remove `replaceAnimations` from noscope option

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,6 @@
 var csjs = require('./csjs');
 
 module.exports = csjs();
-module.exports.csjs = csjs();
+module.exports.csjs = csjs;
 module.exports.noScope = csjs({ noscope: true });
 module.exports.getCss = require('./get-css');

--- a/lib/csjs.js
+++ b/lib/csjs.js
@@ -22,13 +22,7 @@ module.exports = function csjsTemplate(opts) {
     var css = joiner(strings, values.map(selectorize));
     var ignores = ignoreComposition(values);
 
-    var scope;
-    if (noscope) {
-      scope = extractExports(css);
-    } else {
-      scope = scopify(css, ignores);
-    }
-
+    var scope = noscope ? extractExports(css) : scopify(css, ignores);
     var extracted = extractExtends(scope.css);
     var localClasses = without(scope.classes, ignores);
     var localKeyframes = without(scope.keyframes, ignores);

--- a/lib/extract-exports.js
+++ b/lib/extract-exports.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var replaceAnimations = require('./replace-animations');
 var regex = require('./regex');
 var classRegex = regex.classRegex;
 var keyframesRegex = regex.keyframesRegex;
@@ -8,11 +7,11 @@ var keyframesRegex = regex.keyframesRegex;
 module.exports = extractExports;
 
 function extractExports(css) {
-  return replaceAnimations({
+  return {
     css: css,
     keyframes: getExport(css, keyframesRegex),
     classes: getExport(css, classRegex)
-  });
+  };
 }
 
 function getExport(css, regex) {


### PR DESCRIPTION
I also realized after submitting the previous PR that we have no way to get the base `csjs` function which will allow us to customize our parameters to the `csjsHandler`.  This might need a major version bump because it changes the behavior of csjs.csjs.
